### PR TITLE
Migrate to libra 09.01.2020

### DIFF
--- a/language/move-lang/src/lib.rs
+++ b/language/move-lang/src/lib.rs
@@ -20,6 +20,9 @@ pub mod command_line;
 
 pub mod test_utils;
 
+mod stdlib;
+
+pub use stdlib::stdlib;
 use codespan::{ByteIndex, Span};
 use errors::*;
 use parser::syntax::parse_file_string;
@@ -128,7 +131,7 @@ pub fn output_compiled_units(
     Ok(())
 }
 
-fn check_program(
+pub fn check_program(
     prog: Result<parser::ast::Program, Errors>,
     sender_opt: Option<Address>,
 ) -> Result<cfgir::ast::Program, Errors> {
@@ -142,7 +145,7 @@ fn check_program(
     Ok(cprog)
 }
 
-fn compile_program(
+pub fn compile_program(
     prog: Result<parser::ast::Program, Errors>,
     sender_opt: Option<Address>,
 ) -> Result<Vec<to_bytecode::translate::CompiledUnit>, Errors> {
@@ -297,7 +300,7 @@ fn strip_comments(source: &str) -> String {
 
 // We restrict strings to only ascii visual characters (0x20 <= c <= 0x7E) or a permitted newline
 // character--\n--or a tab--\t.
-fn strip_comments_and_verify(fname: &'static str, string: &str) -> Result<String, Error> {
+pub fn strip_comments_and_verify(fname: &'static str, string: &str) -> Result<String, Error> {
     verify_string(fname, string)?;
     Ok(strip_comments(string))
 }

--- a/language/move-lang/src/stdlib.rs
+++ b/language/move-lang/src/stdlib.rs
@@ -1,0 +1,27 @@
+use crate::errors::{FilesSourceText, Errors};
+use std::collections::HashMap;
+use crate::{strip_comments_and_verify, parser, check_program, compile_program};
+use std::io;
+use crate::parser::syntax::parse_file_string;
+use crate::parser::ast::FileDefinition;
+use crate::shared::Address;
+use crate::errors;
+
+pub fn stdlib() -> Vec<&'static str> {
+    vec![
+        include_str!("../stdlib/modules/address_util.move"),
+        include_str!("../stdlib/modules/block.move"),
+        include_str!("../stdlib/modules/bytearray_util.move"),
+        include_str!("../stdlib/modules/event.move"),
+        include_str!("../stdlib/modules/hash.move"),
+        include_str!("../stdlib/modules/libra_account.move"),
+        include_str!("../stdlib/modules/libra_coin.move"),
+        include_str!("../stdlib/modules/signature.move"),
+        include_str!("../stdlib/modules/transaction.move"),
+        include_str!("../stdlib/modules/transaction_fee_distribution.move"),
+        include_str!("../stdlib/modules/u64_util.move"),
+        include_str!("../stdlib/modules/validator_config.move"),
+        include_str!("../stdlib/modules/validator_set.move"),
+        include_str!("../stdlib/modules/vector.move"),
+    ]
+}


### PR DESCRIPTION
Export move stdlib sources.
The change is necessary to implement the move lang compiler for move-vm-in-cosmos.